### PR TITLE
feat: add summoner statistics route

### DIFF
--- a/src/client/components/summoner/navigation/SummonerNavigation.tsx
+++ b/src/client/components/summoner/navigation/SummonerNavigation.tsx
@@ -1,6 +1,12 @@
 import { SummonerNavigationItem } from "@/client/components/summoner/navigation/SummonerNavigationItem";
 import { useParams } from "@tanstack/react-router";
-import { CrownIcon, DatabaseBackupIcon, RadioIcon, ScrollTextIcon } from "lucide-react";
+import {
+  BarChart2Icon,
+  CrownIcon,
+  DatabaseBackupIcon,
+  RadioIcon,
+  ScrollTextIcon,
+} from "lucide-react";
 
 type Props = {};
 
@@ -29,6 +35,17 @@ export const SummonerNavigation = ({}: Props) => {
         activeOptions={{ includeSearch: false }}
       >
         Masteries
+      </SummonerNavigationItem>
+      <SummonerNavigationItem
+        to={"/lol/summoner/$riotID/statistics"}
+        params={params}
+        iconNode={BarChart2Icon}
+        search={{
+          queue: "solo",
+        }}
+        activeOptions={{ includeSearch: false }}
+      >
+        Statistics
       </SummonerNavigationItem>
       <SummonerNavigationItem
         to={"/lol/summoner/$riotID/live"}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,7 +15,7 @@ import { Route as LolSummonerIndexRouteImport } from './routes/lol/summoner/inde
 import { Route as LolFeaturedGamesRegionRouteImport } from './routes/lol/featured-games/$region'
 import { Route as LolSummonerRiotIDRouteRouteImport } from './routes/lol/summoner/$riotID/route'
 import { Route as LolSummonerRiotIDIndexRouteImport } from './routes/lol/summoner/$riotID/index'
-import { Route as LolSummonerRiotIDStatsRouteImport } from './routes/lol/summoner/$riotID/stats'
+import { Route as LolSummonerRiotIDStatisticsRouteImport } from './routes/lol/summoner/$riotID/statistics'
 import { Route as LolSummonerRiotIDRefreshRouteImport } from './routes/lol/summoner/$riotID/refresh'
 import { Route as LolSummonerRiotIDMatchesRouteImport } from './routes/lol/summoner/$riotID/matches'
 import { Route as LolSummonerRiotIDMasteryRouteImport } from './routes/lol/summoner/$riotID/mastery'
@@ -51,11 +51,12 @@ const LolSummonerRiotIDIndexRoute = LolSummonerRiotIDIndexRouteImport.update({
   path: '/',
   getParentRoute: () => LolSummonerRiotIDRouteRoute,
 } as any)
-const LolSummonerRiotIDStatsRoute = LolSummonerRiotIDStatsRouteImport.update({
-  id: '/stats',
-  path: '/stats',
-  getParentRoute: () => LolSummonerRiotIDRouteRoute,
-} as any)
+const LolSummonerRiotIDStatisticsRoute =
+  LolSummonerRiotIDStatisticsRouteImport.update({
+    id: '/statistics',
+    path: '/statistics',
+    getParentRoute: () => LolSummonerRiotIDRouteRoute,
+  } as any)
 const LolSummonerRiotIDRefreshRoute =
   LolSummonerRiotIDRefreshRouteImport.update({
     id: '/refresh',
@@ -90,7 +91,7 @@ export interface FileRoutesByFullPath {
   '/lol/summoner/$riotID/mastery': typeof LolSummonerRiotIDMasteryRoute
   '/lol/summoner/$riotID/matches': typeof LolSummonerRiotIDMatchesRoute
   '/lol/summoner/$riotID/refresh': typeof LolSummonerRiotIDRefreshRoute
-  '/lol/summoner/$riotID/stats': typeof LolSummonerRiotIDStatsRoute
+  '/lol/summoner/$riotID/statistics': typeof LolSummonerRiotIDStatisticsRoute
   '/lol/summoner/$riotID/': typeof LolSummonerRiotIDIndexRoute
 }
 export interface FileRoutesByTo {
@@ -102,7 +103,7 @@ export interface FileRoutesByTo {
   '/lol/summoner/$riotID/mastery': typeof LolSummonerRiotIDMasteryRoute
   '/lol/summoner/$riotID/matches': typeof LolSummonerRiotIDMatchesRoute
   '/lol/summoner/$riotID/refresh': typeof LolSummonerRiotIDRefreshRoute
-  '/lol/summoner/$riotID/stats': typeof LolSummonerRiotIDStatsRoute
+  '/lol/summoner/$riotID/statistics': typeof LolSummonerRiotIDStatisticsRoute
   '/lol/summoner/$riotID': typeof LolSummonerRiotIDIndexRoute
 }
 export interface FileRoutesById {
@@ -116,7 +117,7 @@ export interface FileRoutesById {
   '/lol/summoner/$riotID/mastery': typeof LolSummonerRiotIDMasteryRoute
   '/lol/summoner/$riotID/matches': typeof LolSummonerRiotIDMatchesRoute
   '/lol/summoner/$riotID/refresh': typeof LolSummonerRiotIDRefreshRoute
-  '/lol/summoner/$riotID/stats': typeof LolSummonerRiotIDStatsRoute
+  '/lol/summoner/$riotID/statistics': typeof LolSummonerRiotIDStatisticsRoute
   '/lol/summoner/$riotID/': typeof LolSummonerRiotIDIndexRoute
 }
 export interface FileRouteTypes {
@@ -131,7 +132,7 @@ export interface FileRouteTypes {
     | '/lol/summoner/$riotID/mastery'
     | '/lol/summoner/$riotID/matches'
     | '/lol/summoner/$riotID/refresh'
-    | '/lol/summoner/$riotID/stats'
+    | '/lol/summoner/$riotID/statistics'
     | '/lol/summoner/$riotID/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -143,7 +144,7 @@ export interface FileRouteTypes {
     | '/lol/summoner/$riotID/mastery'
     | '/lol/summoner/$riotID/matches'
     | '/lol/summoner/$riotID/refresh'
-    | '/lol/summoner/$riotID/stats'
+    | '/lol/summoner/$riotID/statistics'
     | '/lol/summoner/$riotID'
   id:
     | '__root__'
@@ -156,7 +157,7 @@ export interface FileRouteTypes {
     | '/lol/summoner/$riotID/mastery'
     | '/lol/summoner/$riotID/matches'
     | '/lol/summoner/$riotID/refresh'
-    | '/lol/summoner/$riotID/stats'
+    | '/lol/summoner/$riotID/statistics'
     | '/lol/summoner/$riotID/'
   fileRoutesById: FileRoutesById
 }
@@ -209,11 +210,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LolSummonerRiotIDIndexRouteImport
       parentRoute: typeof LolSummonerRiotIDRouteRoute
     }
-    '/lol/summoner/$riotID/stats': {
-      id: '/lol/summoner/$riotID/stats'
-      path: '/stats'
-      fullPath: '/lol/summoner/$riotID/stats'
-      preLoaderRoute: typeof LolSummonerRiotIDStatsRouteImport
+    '/lol/summoner/$riotID/statistics': {
+      id: '/lol/summoner/$riotID/statistics'
+      path: '/statistics'
+      fullPath: '/lol/summoner/$riotID/statistics'
+      preLoaderRoute: typeof LolSummonerRiotIDStatisticsRouteImport
       parentRoute: typeof LolSummonerRiotIDRouteRoute
     }
     '/lol/summoner/$riotID/refresh': {
@@ -252,7 +253,7 @@ interface LolSummonerRiotIDRouteRouteChildren {
   LolSummonerRiotIDMasteryRoute: typeof LolSummonerRiotIDMasteryRoute
   LolSummonerRiotIDMatchesRoute: typeof LolSummonerRiotIDMatchesRoute
   LolSummonerRiotIDRefreshRoute: typeof LolSummonerRiotIDRefreshRoute
-  LolSummonerRiotIDStatsRoute: typeof LolSummonerRiotIDStatsRoute
+  LolSummonerRiotIDStatisticsRoute: typeof LolSummonerRiotIDStatisticsRoute
   LolSummonerRiotIDIndexRoute: typeof LolSummonerRiotIDIndexRoute
 }
 
@@ -262,7 +263,7 @@ const LolSummonerRiotIDRouteRouteChildren: LolSummonerRiotIDRouteRouteChildren =
     LolSummonerRiotIDMasteryRoute: LolSummonerRiotIDMasteryRoute,
     LolSummonerRiotIDMatchesRoute: LolSummonerRiotIDMatchesRoute,
     LolSummonerRiotIDRefreshRoute: LolSummonerRiotIDRefreshRoute,
-    LolSummonerRiotIDStatsRoute: LolSummonerRiotIDStatsRoute,
+    LolSummonerRiotIDStatisticsRoute: LolSummonerRiotIDStatisticsRoute,
     LolSummonerRiotIDIndexRoute: LolSummonerRiotIDIndexRoute,
   }
 

--- a/src/routes/lol/summoner/$riotID/statistics.tsx
+++ b/src/routes/lol/summoner/$riotID/statistics.tsx
@@ -1,0 +1,168 @@
+import { Input } from "@/client/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/client/components/ui/select";
+import { useGetSummonerStatistics } from "@/client/queries/getSummonerStatistics";
+import { FriendlyQueueTypes, friendlyQueueTypeToRiot } from "@/client/lib/typeHelper";
+import { individualPositions } from "@/server/api-route/riot/match/MatchDTO";
+import { createFileRoute, useLoaderData, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import React from "react";
+import * as v from "valibot";
+
+export const Route = createFileRoute("/lol/summoner/$riotID/statistics")({
+  component: RouteComponent,
+  validateSearch: (raw) =>
+    v.parse(
+      v.object({
+        queue: v.exactOptional(v.picklist(FriendlyQueueTypes), "solo"),
+        champion: v.pipe(
+          v.exactOptional(v.string()),
+          v.transform((s) => s || undefined),
+        ),
+        position: v.exactOptional(v.picklist(individualPositions)),
+      }),
+      raw,
+    ),
+});
+
+function RouteComponent() {
+  const { summoner } = useLoaderData({ from: "/lol/summoner/$riotID" });
+  const metadata = useLoaderData({ from: "/lol" });
+  const search = useSearch({ from: "/lol/summoner/$riotID/statistics" });
+  const params = useParams({ from: "/lol/summoner/$riotID" });
+  const navigate = useNavigate({ from: "/lol/summoner/$riotID/statistics" });
+
+  const { data, isPending, isError } = useGetSummonerStatistics({
+    summoner,
+  });
+
+  const queueStat = React.useMemo(() => {
+    if (!data) return null;
+    return data.find(
+      (s) => s.queueType === friendlyQueueTypeToRiot(search.queue),
+    );
+  }, [data, search.queue]);
+
+  const championStats = React.useMemo(() => {
+    if (!queueStat) return [];
+    let list = queueStat.statsByChampionId;
+    if (search.champion) {
+      list = list.filter((c) => {
+        const name = metadata.champions[c.championId]?.name ?? "";
+        return name.toLowerCase().includes(search.champion!.toLowerCase());
+      });
+    }
+    return list;
+  }, [queueStat, search.champion, metadata.champions]);
+
+  const positionStats = React.useMemo(() => {
+    if (!queueStat) return [];
+    let list = queueStat.statsByIndividualPosition;
+    if (search.position) {
+      list = list.filter((p) => p.individualPosition === search.position);
+    }
+    return list;
+  }, [queueStat, search.position]);
+
+  if (isPending) return <div>Loading...</div>;
+  if (isError || !queueStat) return <div>Error loading statistics</div>;
+
+  return (
+    <div className="flex flex-col gap-4 flex-1">
+      <div className="flex gap-4 flex-wrap">
+        <div className="flex items-center gap-2">
+          <label>Queue</label>
+          <Select
+            value={search.queue}
+            onValueChange={(v) =>
+              navigate({
+                to: "/lol/summoner/$riotID/statistics",
+                params,
+                search: (s) => ({ ...s, queue: v }),
+              })
+            }
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="solo">Ranked Solo Duo</SelectItem>
+              <SelectItem value="flex">Ranked Flex</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label>Champion</label>
+          <Input
+            className="w-40"
+            value={search.champion ?? ""}
+            onChange={(e) =>
+              navigate({
+                to: "/lol/summoner/$riotID/statistics",
+                params,
+                replace: true,
+                search: (s) => ({
+                  ...s,
+                  champion: e.currentTarget.value || undefined,
+                }),
+              })
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label>Position</label>
+          <Select
+            value={search.position ?? ""}
+            onValueChange={(v) =>
+              navigate({
+                to: "/lol/summoner/$riotID/statistics",
+                params,
+                search: (s) => ({
+                  ...s,
+                  position: v || undefined,
+                }),
+              })
+            }
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">All</SelectItem>
+              {individualPositions.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div>
+        <h2 className="font-semibold">Stats by Champion</h2>
+        <ul className="list-disc pl-4">
+          {championStats.map((c) => (
+            <li key={c.championId}>
+              {metadata.champions[c.championId]?.name ?? c.championId}: {c.wins}W {c.losses}L
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="font-semibold">Stats by Position</h2>
+        <ul className="list-disc pl-4">
+          {positionStats.map((p) => (
+            <li key={p.individualPosition}>
+              {p.individualPosition}: {p.wins}W {p.losses}L
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/src/routes/lol/summoner/$riotID/statistics.tsx
+++ b/src/routes/lol/summoner/$riotID/statistics.tsx
@@ -7,9 +7,22 @@ import {
   SelectValue,
 } from "@/client/components/ui/select";
 import { useGetSummonerStatistics } from "@/client/queries/getSummonerStatistics";
-import { FriendlyQueueTypes, friendlyQueueTypeToRiot } from "@/client/lib/typeHelper";
-import { individualPositions } from "@/server/api-route/riot/match/MatchDTO";
-import { createFileRoute, useLoaderData, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import {
+  FriendlyQueueTypes,
+  friendlyQueueTypeToRiot,
+  type FriendlyQueueType,
+} from "@/client/lib/typeHelper";
+import {
+  individualPositions,
+  type IndividualPositionType,
+} from "@/server/api-route/riot/match/MatchDTO";
+import {
+  createFileRoute,
+  useLoaderData,
+  useNavigate,
+  useParams,
+  useSearch,
+} from "@tanstack/react-router";
 import React from "react";
 import * as v from "valibot";
 
@@ -42,9 +55,7 @@ function RouteComponent() {
 
   const queueStat = React.useMemo(() => {
     if (!data) return null;
-    return data.find(
-      (s) => s.queueType === friendlyQueueTypeToRiot(search.queue),
-    );
+    return data.find((s) => s.queueType === friendlyQueueTypeToRiot(search.queue));
   }, [data, search.queue]);
 
   const championStats = React.useMemo(() => {
@@ -78,13 +89,13 @@ function RouteComponent() {
           <label>Queue</label>
           <Select
             value={search.queue}
-            onValueChange={(v) =>
+            onValueChange={(v: FriendlyQueueType) => {
               navigate({
                 to: "/lol/summoner/$riotID/statistics",
                 params,
                 search: (s) => ({ ...s, queue: v }),
-              })
-            }
+              }).catch(console.error);
+            }}
           >
             <SelectTrigger className="w-40">
               <SelectValue />
@@ -100,7 +111,7 @@ function RouteComponent() {
           <Input
             className="w-40"
             value={search.champion ?? ""}
-            onChange={(e) =>
+            onChange={(e) => {
               navigate({
                 to: "/lol/summoner/$riotID/statistics",
                 params,
@@ -109,30 +120,30 @@ function RouteComponent() {
                   ...s,
                   champion: e.currentTarget.value || undefined,
                 }),
-              })
-            }
+              }).catch(console.error);
+            }}
           />
         </div>
         <div className="flex items-center gap-2">
           <label>Position</label>
           <Select
             value={search.position ?? ""}
-            onValueChange={(v) =>
+            onValueChange={(v: IndividualPositionType) => {
               navigate({
                 to: "/lol/summoner/$riotID/statistics",
                 params,
                 search: (s) => ({
                   ...s,
-                  position: v || undefined,
+                  position: v === "Invalid" ? undefined : v,
                 }),
-              })
-            }
+              }).catch(console.error);
+            }}
           >
             <SelectTrigger className="w-40">
               <SelectValue placeholder="All" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All</SelectItem>
+              <SelectItem value="Invalid">All</SelectItem>
               {individualPositions.map((p) => (
                 <SelectItem key={p} value={p}>
                   {p}
@@ -165,4 +176,3 @@ function RouteComponent() {
     </div>
   );
 }
-

--- a/src/routes/lol/summoner/$riotID/stats.tsx
+++ b/src/routes/lol/summoner/$riotID/stats.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/lol/summoner/$riotID/stats")({
-  component: RouteComponent,
-});
-
-function RouteComponent() {
-  return <div>Hello "/lol/summoner/$riotID/stats"!</div>;
-}


### PR DESCRIPTION
## Summary
- add statistics page for summoner with filtering by queue, champion and position via URL search params
- link new statistics page in summoner navigation

## Testing
- `bun run lint:fix` *(fails: Unsafe assignment and other TS eslint errors)*
- `bun run types` *(fails: cannot find module '@/server/services/match', implicit any and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d9002d083229477783c5c166cff