### PR TITLE
feat: add magical landing page

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,20 +1,56 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Sparkles, Search, Gamepad2, BarChart3, type LucideIcon } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Home,
-  beforeLoad: () => {
-    throw redirect({
-      to: "/lol/summoner",
-    });
-  },
 });
 
 function Home() {
+  const features: { icon: LucideIcon; title: string; description: string; to: string }[] = [
+    {
+      icon: Search,
+      title: "Summoner Lookup",
+      description: "Find player stats by Riot ID.",
+      to: "/lol/summoner",
+    },
+    {
+      icon: Gamepad2,
+      title: "Featured Games",
+      description: "Watch live games across regions.",
+      to: "/lol/featured-games/na1",
+    },
+    {
+      icon: BarChart3,
+      title: "Match Insights",
+      description: "Dive into detailed match statistics.",
+      to: "/lol/summoner",
+    },
+  ];
+
   return (
-    <div className={"w-full h-full flex items-center justify-center flex-1"}>
-      <Link to={"/lol/summoner"}>
-        <h1 className={"text-neutral-900 text-[200px] font-extrabold"}>(League of Legends)</h1>
-      </Link>
+    <div className="flex flex-col items-center justify-center w-full h-full p-8 overflow-auto">
+      <section className="text-center space-y-4 mb-16">
+        <Sparkles className="mx-auto w-12 h-12 text-fuchsia-400 animate-pulse" />
+        <h1 className="text-5xl font-black bg-gradient-to-r from-fuchsia-400 via-purple-400 to-indigo-400 bg-clip-text text-transparent">
+          Welcome to puuid.com
+        </h1>
+        <p className="text-neutral-400 max-w-xl mx-auto">
+          Explore League of Legends data with a touch of magic.
+        </p>
+      </section>
+      <section className="grid gap-8 w-full max-w-5xl sm:grid-cols-2 lg:grid-cols-3">
+        {features.map(({ icon: Icon, title, description, to }) => (
+          <Link
+            key={title}
+            to={to}
+            className="group p-6 rounded-xl border border-neutral-800 bg-neutral-900/50 hover:border-fuchsia-500 transition-colors backdrop-blur"
+          >
+            <Icon className="w-10 h-10 text-fuchsia-400 mb-4 group-hover:animate-bounce" />
+            <h3 className="text-xl font-semibold text-neutral-100">{title}</h3>
+            <p className="mt-2 text-sm text-neutral-400">{description}</p>
+          </Link>
+        ))}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace root redirect with a new landing page
- showcase summoner lookup, featured games, and match insights
- add magical styling with lucide icons and gradient hero

## Testing
- `bun run types` *(fails: Cannot find module '@/server/services/match' and other type errors)*
- `bun run format` *(fails: Code style issues found in src/routeTree.gen.ts)*
- `npx prettier src/routes/index.tsx --check`


------
https://chatgpt.com/codex/tasks/task_e_68ae1dd9ae088322bab53cc97aaa3239