### PR TITLE
feat: add SSR cached landing page

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,20 +1,48 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Button } from "@/client/components/ui/button";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/client/components/ui/card";
+import { $getLandingInfo, type $GetLandingInfoType } from "@/server/functions/$getLandingInfo";
+import { Search, Activity, Star, BarChart3, type LucideIcon } from "lucide-react";
+
+const icons: Record<string, LucideIcon> = {
+  Search,
+  Activity,
+  Star,
+  BarChart3,
+};
 
 export const Route = createFileRoute("/")({
-  component: Home,
-  beforeLoad: () => {
-    throw redirect({
-      to: "/lol/summoner",
-    });
-  },
+  loader: () => $getLandingInfo(),
+  component: Landing,
 });
 
-function Home() {
+function Landing() {
+  const { features } = Route.useLoaderData() as $GetLandingInfoType;
   return (
-    <div className={"w-full h-full flex items-center justify-center flex-1"}>
-      <Link to={"/lol/summoner"}>
-        <h1 className={"text-neutral-900 text-[200px] font-extrabold"}>(League of Legends)</h1>
-      </Link>
+    <div className="container mx-auto flex flex-col items-center gap-16 py-24 text-center">
+      <section className="flex max-w-2xl flex-col items-center gap-6">
+        <h1 className="text-5xl font-extrabold tracking-tight text-neutral-100">puuid.com</h1>
+        <p className="text-lg text-neutral-400">
+          Stats, match history and live game info for League of Legends
+        </p>
+        <Button asChild className="mt-4">
+          <Link to="/lol/summoner">Get Started</Link>
+        </Button>
+      </section>
+      <section className="grid w-full max-w-5xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {features.map((f) => {
+          const Icon = icons[f.icon];
+          return (
+            <Card key={f.title} className="bg-neutral-900 border-neutral-800">
+              <CardHeader className="items-center text-center gap-3">
+                {Icon ? <Icon className="h-6 w-6 text-neutral-200" /> : null}
+                <CardTitle className="text-neutral-100">{f.title}</CardTitle>
+                <CardDescription className="text-neutral-400">{f.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          );
+        })}
+      </section>
     </div>
   );
 }

--- a/src/server/functions/$getLandingInfo.ts
+++ b/src/server/functions/$getLandingInfo.ts
@@ -1,0 +1,32 @@
+import { createServerFn } from "@tanstack/react-start";
+
+export const $getLandingInfo = createServerFn({ method: "GET" })
+  .type("static")
+  .handler(async () => {
+    return {
+      features: [
+        {
+          title: "Summoner Search",
+          description: "Look up any summoner by Riot ID and explore their profile.",
+          icon: "Search",
+        },
+        {
+          title: "Live Match Tracking",
+          description: "Check active games to see who is on the Rift right now.",
+          icon: "Activity",
+        },
+        {
+          title: "Champion Mastery",
+          description: "Discover top champions and mastery scores for every player.",
+          icon: "Star",
+        },
+        {
+          title: "Match Statistics",
+          description: "Dive into detailed match histories and performance analytics.",
+          icon: "BarChart3",
+        },
+      ],
+    } as const;
+  });
+
+export type $GetLandingInfoType = Awaited<ReturnType<typeof $getLandingInfo>>;


### PR DESCRIPTION
## Summary
- add static server function for landing page content
- create new landing page with features and call-to-action

## Testing
- `bun run types` *(fails: Cannot find module '@/server/services/league/type' and other TypeScript errors)*
- `bunx prettier src/routes/index.tsx src/server/functions/$getLandingInfo.ts --check`


------
https://chatgpt.com/codex/tasks/task_e_68ae2325c8f083228cf91c082cf6e029